### PR TITLE
AIMD congestion control fix

### DIFF
--- a/NDNc/pipeline/pipeline-interests-aimd.cpp
+++ b/NDNc/pipeline/pipeline-interests-aimd.cpp
@@ -177,9 +177,7 @@ void PipelineInterestsAimd::decreaseWindow() {
     LOG_DEBUG("window decrease at %li", m_windowSize);
     m_windowSize /= 2;
     m_windowIncCounter = 0;
-    if (m_windowSize < MIN_WINDOW) {
-        m_windowSize = MIN_WINDOW;
-    }
+    m_windowSize = std::max(m_windowSize, MIN_WINDOW);
     m_lastDecrease = now;
 }
 
@@ -188,9 +186,7 @@ void PipelineInterestsAimd::increaseWindow() {
     if (m_windowIncCounter >= m_windowSize) {
         m_windowSize++;
         m_windowIncCounter = 0;
-        if (m_windowSize > MAX_WINDOW) {
-            m_windowSize = MAX_WINDOW;
-        }
+        m_windowSize = std::min(m_windowSize, MAX_WINDOW);
     }
 }
 

--- a/NDNc/pipeline/pipeline-interests-aimd.cpp
+++ b/NDNc/pipeline/pipeline-interests-aimd.cpp
@@ -30,7 +30,7 @@
 
 namespace ndnc {
 PipelineInterestsAimd::PipelineInterestsAimd(Face &face, size_t size)
-    : PipelineInterests(face), m_windowSize{size},
+    : PipelineInterests(face), m_windowSize{size}, m_windowIncCounter{0},
       m_lastDecrease{ndn::time::steady_clock::now()} {}
 
 PipelineInterestsAimd::~PipelineInterestsAimd() {
@@ -176,6 +176,7 @@ void PipelineInterestsAimd::decreaseWindow() {
 
     LOG_DEBUG("window decrease at %li", m_windowSize);
     m_windowSize /= 2;
+    m_windowIncCounter = 0;
     if (m_windowSize < MIN_WINDOW) {
         m_windowSize = MIN_WINDOW;
     }
@@ -183,9 +184,13 @@ void PipelineInterestsAimd::decreaseWindow() {
 }
 
 void PipelineInterestsAimd::increaseWindow() {
-    m_windowSize++;
-    if (m_windowSize > MAX_WINDOW) {
-        m_windowSize = MAX_WINDOW;
+    m_windowIncCounter++;
+    if (m_windowIncCounter >= m_windowSize) {
+        m_windowSize++;
+        m_windowIncCounter = 0;
+        if (m_windowSize > MAX_WINDOW) {
+            m_windowSize = MAX_WINDOW;
+        }
     }
 }
 

--- a/NDNc/pipeline/pipeline-interests-aimd.hpp
+++ b/NDNc/pipeline/pipeline-interests-aimd.hpp
@@ -56,8 +56,8 @@ class PipelineInterestsAimd : public PipelineInterests {
     size_t m_windowSize;
     size_t m_windowIncCounter;
     ndn::time::steady_clock::time_point m_lastDecrease;
-    static const unsigned MAX_WINDOW = 65536;
-    static const unsigned MIN_WINDOW = 8;
+    static const size_t MAX_WINDOW = 65536;
+    static const size_t MIN_WINDOW = 8;
     constexpr static const ndn::time::milliseconds MAX_RTT =
         ndn::time::milliseconds{3};
 };

--- a/NDNc/pipeline/pipeline-interests-aimd.hpp
+++ b/NDNc/pipeline/pipeline-interests-aimd.hpp
@@ -54,6 +54,7 @@ class PipelineInterestsAimd : public PipelineInterests {
 
   private:
     size_t m_windowSize;
+    size_t m_windowIncCounter;
     ndn::time::steady_clock::time_point m_lastDecrease;
     static const unsigned MAX_WINDOW = 65536;
     static const unsigned MIN_WINDOW = 8;


### PR DESCRIPTION
This PR fixes the existing incorrect implementation of the additive increase. The existing behavior is that the window will increase by one packet on every received data, which means the window size will double every RTT when the pipe is not full (exactly as TCP slow start).

The intended behavior is that for every RTT, the window size is increased by one. Thus for every data packet, the window size is increased by roughly 1/window_size. 